### PR TITLE
Cache requests

### DIFF
--- a/app/controllers/authenticated_controller.rb
+++ b/app/controllers/authenticated_controller.rb
@@ -1,0 +1,3 @@
+class AuthenticatedController < ApplicationController
+  before_action :authenticate_user!
+end

--- a/app/models/comic.rb
+++ b/app/models/comic.rb
@@ -1,0 +1,43 @@
+class Comic < OpenStruct
+  # Each comic has a title that follows this format: name + year + issuenumber, for
+  # example "Brilliant (2011) #7". Captures each part separately.
+  TITLE_FORMAT = %r{(.*) \((.*)\) \#(.*)}
+  TITLE_NO_ELEMENTS = 3
+  NAME_POS = 1
+  YEAR_POS = 2
+
+  def to_partial_path
+    'comic'.freeze
+  end
+
+  # Get the name of the comic without the comic's starting year or issuenumber, for example
+  #
+  # > Comic.new(title: "Brilliant (2011) #7").name
+  # => "Brilliant"
+  def name
+    scrape_title(NAME_POS)
+  end
+
+  # Get the year
+  #
+  # > Comic.new(title: "Brilliant (2011) #7").year
+  # => "Brilliant"
+  def year
+    scrape_title(YEAR_POS)
+  end
+
+  # Builds the comic's thumbnail image path by concatenating its filepath and extension. More info
+  # at http://developer.marvel.com/documentation/images
+  def thumb_path
+    [thumbnail['path'], thumbnail['extension']].join('.')
+  end
+
+  private
+
+  # Parses the title and use regular expressions to scrape its information
+  def scrape_title(position)
+    matches = title.match(TITLE_FORMAT)
+
+    matches.size > TITLE_NO_ELEMENTS ? matches[position] : title
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,6 @@
+class User < ApplicationRecord
+  # Include default devise modules. Others available are:
+  # :confirmable, :lockable, :timeoutable and :omniauthable
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :trackable, :validatable
+end

--- a/app/use_cases/comics/index/base.rb
+++ b/app/use_cases/comics/index/base.rb
@@ -5,7 +5,7 @@ module Comics
 
       # Maps cached or new comics data into a collection of Comics
       def perform
-        context.comics = context.comics_data.map { |comic| OpenStruct.new(comic) }
+        context.comics = context.comics_data.map { |comic| Comic.new(comic) }
       end
     end
   end

--- a/app/use_cases/comics/index/cache.rb
+++ b/app/use_cases/comics/index/cache.rb
@@ -1,0 +1,38 @@
+require 'redis'
+require 'json'
+
+module Comics
+  module Index
+    class Cache
+      def write(key, value, ttl = false)
+        dump = value.to_json
+
+        if ttl
+          redis.setex(key.to_s, ttl, dump)
+        else
+          redis.set(key.to_s, dump)
+        end
+      end
+
+      def read(key)
+        dump = redis.get(key)
+
+        return unless dump
+
+        JSON.parse(dump)
+      end
+
+      def delete(key)
+        redis.del(key)
+      end
+
+      alias del delete
+
+      private
+
+      def redis
+        ::Redis.current
+      end
+    end
+  end
+end

--- a/app/use_cases/comics/index/fetch_comics.rb
+++ b/app/use_cases/comics/index/fetch_comics.rb
@@ -5,7 +5,56 @@ module Comics
       DEFAULT_PAGE_LIMIT = 20
       DEFAULT_COMIC_FORMAT = 'comic'
 
+      # According to http://developer.marvel.com/documentation/attribution we should cache data
+      # only for 24 hours
+      DEFAULT_CACHE_TTL = 60 * 60 * 24 # 24 hours in seconds
+      DEFAULT_CACHE_KEY = 'marvel_request:%s'.freeze
+
       def perform
+        context.comics_data = fetch_and_cache(cache_key) do
+          fetch_comics_from_marvel
+        end
+      end
+
+      private
+
+      def cache
+        @cache ||= Cache.new
+      end
+
+      def cache_key
+        format(DEFAULT_CACHE_KEY, Digest::SHA1.hexdigest("#{Date.today}#{context_params}"))
+      end
+
+      # This methods checks if there is a value cached according to a key, and returns it there is.
+      # If there is no value cached using this key and if a block is passed, it saves the block's
+      # return data and returns it, i.e. this method behaves just like ruby's "||=" operator. E.g.:
+      #
+      # > fetch_and_cache('test')
+      # => nil
+      # > fetch_and_cache('test') do
+      #      'hello'
+      #   end
+      # => 'hello'
+      # > fetch_and_cache('test')
+      # => 'hello'
+      def fetch_and_cache(key)
+        comics_data = cache.read(key)
+
+        # If there is a comics_data cached, return that comics_data instead
+        return comics_data if comics_data
+
+        # If not, execute the block and cache the response data
+        if block_given?
+          comics_data = yield
+
+          cache.write(key, comics_data, DEFAULT_CACHE_TTL)
+        end
+
+        comics_data
+      end
+
+      def fetch_comics_from_marvel
         api = Marvelite::API::Client.new(
           public_key: ENV['MARVEL_API_PUBLIC_KEY'],
           private_key: ENV['MARVEL_API_PRIVATE_KEY']
@@ -13,16 +62,22 @@ module Comics
 
         # REQ1: "I want to see a list of all Marvel's released comic books covers ordered from
         # most recent to the oldest"
-        comics_data = api.comics(
-          format: DEFAULT_COMIC_FORMAT,
-          orderBy: DEFAULT_ORDER_BY,
-          offset: context.offset || 0,
-          limit: context.limit || DEFAULT_PAGE_LIMIT
-        )
+        comics_data = api.comics(context_params)
 
         # Ruby's 2.3 dig method will return the value of the parameter ["data"]["results"] and it
         # will return nil if data or results are not present
-        context.comics_data = comics_data.dig(:data, :results)
+        comics_data.dig(:data, :results)
+      end
+
+      def context_params
+        @_context ||= begin
+          {
+            format: DEFAULT_COMIC_FORMAT,
+            orderBy: DEFAULT_ORDER_BY,
+            offset: context.offset || 0,
+            limit: context.limit || DEFAULT_PAGE_LIMIT
+          }
+        end
       end
     end
   end

--- a/app/use_cases/comics/index/fetch_comics.rb
+++ b/app/use_cases/comics/index/fetch_comics.rb
@@ -3,6 +3,7 @@ module Comics
     class FetchComics < UseCase::Base
       DEFAULT_ORDER_BY = '-onsaleDate'.freeze
       DEFAULT_PAGE_LIMIT = 20
+      DEFAULT_COMIC_FORMAT = 'comic'
 
       def perform
         api = Marvelite::API::Client.new(
@@ -13,6 +14,7 @@ module Comics
         # REQ1: "I want to see a list of all Marvel's released comic books covers ordered from
         # most recent to the oldest"
         comics_data = api.comics(
+          format: DEFAULT_COMIC_FORMAT,
           orderBy: DEFAULT_ORDER_BY,
           offset: context.offset || 0,
           limit: context.limit || DEFAULT_PAGE_LIMIT

--- a/app/views/comics/_comic.html.erb
+++ b/app/views/comics/_comic.html.erb
@@ -1,1 +1,4 @@
-<h3><%= comic.title %></h3>
+<h3><%= comic.name %></h3>
+<h4><%= comic.year %> - #<%= comic.issueNumber %></h4>
+
+<%= image_tag comic.thumb_path, width: '110' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,9 @@
   </head>
 
   <body>
+	<p class="notice"><%= notice %></p>
+    <p class="alert"><%= alert %></p>
+       
     <%= yield %>
   </body>
 </html>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,0 +1,268 @@
+# Use this hook to configure devise mailer, warden hooks and so forth.
+# Many of these configuration options can be set straight in your model.
+Devise.setup do |config|
+  # The secret key used by Devise. Devise uses this key to generate
+  # random tokens. Changing this key will render invalid all existing
+  # confirmation, reset password and unlock tokens in the database.
+  # Devise will use the `secret_key_base` as its `secret_key`
+  # by default. You can change it below and use your own secret key.
+  # config.secret_key = '053c8da4d1ee2acce9943882eca67bf9187895a92758f6fdaf0e7649906c7a4322d543ae5065468739afbab8e4cc3490aeef47a0df5898336d55a19a2a80097c'
+
+  # Configure the class responsible to send e-mails.
+  # config.mailer = 'Devise::Mailer'
+
+  # Configure the parent class responsible to send e-mails.
+  # config.parent_mailer = 'ActionMailer::Base'
+
+  # ==> ORM configuration
+  # Load and configure the ORM. Supports :active_record (default) and
+  # :mongoid (bson_ext recommended) by default. Other ORMs may be
+  # available as additional gems.
+  require 'devise/orm/active_record'
+
+  # ==> Configuration for any authentication mechanism
+  # Configure which keys are used when authenticating a user. The default is
+  # just :email. You can configure it to use [:username, :subdomain], so for
+  # authenticating a user, both parameters are required. Remember that those
+  # parameters are used only when authenticating and not when retrieving from
+  # session. If you need permissions, you should implement that in a before filter.
+  # You can also supply a hash where the value is a boolean determining whether
+  # or not authentication should be aborted when the value is not present.
+  # config.authentication_keys = [:email]
+
+  # Configure parameters from the request object used for authentication. Each entry
+  # given should be a request method and it will automatically be passed to the
+  # find_for_authentication method and considered in your model lookup. For instance,
+  # if you set :request_keys to [:subdomain], :subdomain will be used on authentication.
+  # The same considerations mentioned for authentication_keys also apply to request_keys.
+  # config.request_keys = []
+
+  # Configure which authentication keys should be case-insensitive.
+  # These keys will be downcased upon creating or modifying a user and when used
+  # to authenticate or find a user. Default is :email.
+  config.case_insensitive_keys = [:email]
+
+  # Configure which authentication keys should have whitespace stripped.
+  # These keys will have whitespace before and after removed upon creating or
+  # modifying a user and when used to authenticate or find a user. Default is :email.
+  config.strip_whitespace_keys = [:email]
+
+  # Tell if authentication through request.params is enabled. True by default.
+  # It can be set to an array that will enable params authentication only for the
+  # given strategies, for example, `config.params_authenticatable = [:database]` will
+  # enable it only for database (email + password) authentication.
+  # config.params_authenticatable = true
+
+  # Tell if authentication through HTTP Auth is enabled. False by default.
+  # It can be set to an array that will enable http authentication only for the
+  # given strategies, for example, `config.http_authenticatable = [:database]` will
+  # enable it only for database authentication. The supported strategies are:
+  # :database      = Support basic authentication with authentication key + password
+  # config.http_authenticatable = false
+
+  # If 401 status code should be returned for AJAX requests. True by default.
+  # config.http_authenticatable_on_xhr = true
+
+  # The realm used in Http Basic Authentication. 'Application' by default.
+  # config.http_authentication_realm = 'Application'
+
+  # It will change confirmation, password recovery and other workflows
+  # to behave the same regardless if the e-mail provided was right or wrong.
+  # Does not affect registerable.
+  # config.paranoid = true
+
+  # By default Devise will store the user in session. You can skip storage for
+  # particular strategies by setting this option.
+  # Notice that if you are skipping storage for all authentication paths, you
+  # may want to disable generating routes to Devise's sessions controller by
+  # passing skip: :sessions to `devise_for` in your config/routes.rb
+  config.skip_session_storage = [:http_auth]
+
+  # By default, Devise cleans up the CSRF token on authentication to
+  # avoid CSRF token fixation attacks. This means that, when using AJAX
+  # requests for sign in and sign up, you need to get a new CSRF token
+  # from the server. You can disable this option at your own risk.
+  # config.clean_up_csrf_token_on_authentication = true
+
+  # When false, Devise will not attempt to reload routes on eager load.
+  # This can reduce the time taken to boot the app but if your application
+  # requires the Devise mappings to be loaded during boot time the application
+  # won't boot properly.
+  # config.reload_routes = true
+
+  # ==> Configuration for :database_authenticatable
+  # For bcrypt, this is the cost for hashing the password and defaults to 11. If
+  # using other algorithms, it sets how many times you want the password to be hashed.
+  #
+  # Limiting the stretches to just one in testing will increase the performance of
+  # your test suite dramatically. However, it is STRONGLY RECOMMENDED to not use
+  # a value less than 10 in other environments. Note that, for bcrypt (the default
+  # algorithm), the cost increases exponentially with the number of stretches (e.g.
+  # a value of 20 is already extremely slow: approx. 60 seconds for 1 calculation).
+  config.stretches = Rails.env.test? ? 1 : 11
+
+  # Set up a pepper to generate the hashed password.
+  # config.pepper = 'bbd51a96177683bed1557118ce856c2f6c8444fbb565d0f53fa0fb37bee2162d7a76c8d8236667d5a7872f079f86fc73863307bed5931abd6308f66ca4335fd1'
+
+  # Send a notification email when the user's password is changed
+  # config.send_password_change_notification = false
+
+  # ==> Configuration for :confirmable
+  # A period that the user is allowed to access the website even without
+  # confirming their account. For instance, if set to 2.days, the user will be
+  # able to access the website for two days without confirming their account,
+  # access will be blocked just in the third day. Default is 0.days, meaning
+  # the user cannot access the website without confirming their account.
+  # config.allow_unconfirmed_access_for = 2.days
+
+  # A period that the user is allowed to confirm their account before their
+  # token becomes invalid. For example, if set to 3.days, the user can confirm
+  # their account within 3 days after the mail was sent, but on the fourth day
+  # their account can't be confirmed with the token any more.
+  # Default is nil, meaning there is no restriction on how long a user can take
+  # before confirming their account.
+  # config.confirm_within = 3.days
+
+  # If true, requires any email changes to be confirmed (exactly the same way as
+  # initial account confirmation) to be applied. Requires additional unconfirmed_email
+  # db field (see migrations). Until confirmed, new email is stored in
+  # unconfirmed_email column, and copied to email column on successful confirmation.
+  config.reconfirmable = true
+
+  # Defines which key will be used when confirming an account
+  # config.confirmation_keys = [:email]
+
+  # ==> Configuration for :rememberable
+  # The time the user will be remembered without asking for credentials again.
+  # config.remember_for = 2.weeks
+
+  # Invalidates all the remember me tokens when the user signs out.
+  config.expire_all_remember_me_on_sign_out = true
+
+  # If true, extends the user's remember period when remembered via cookie.
+  # config.extend_remember_period = false
+
+  # Options to be passed to the created cookie. For instance, you can set
+  # secure: true in order to force SSL only cookies.
+  # config.rememberable_options = {}
+
+  # ==> Configuration for :validatable
+  # Range for password length.
+  config.password_length = 6..128
+
+  # Email regex used to validate email formats. It simply asserts that
+  # one (and only one) @ exists in the given string. This is mainly
+  # to give user feedback and not to assert the e-mail validity.
+  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+
+  # ==> Configuration for :timeoutable
+  # The time you want to timeout the user session without activity. After this
+  # time the user will be asked for credentials again. Default is 30 minutes.
+  # config.timeout_in = 30.minutes
+
+  # ==> Configuration for :lockable
+  # Defines which strategy will be used to lock an account.
+  # :failed_attempts = Locks an account after a number of failed attempts to sign in.
+  # :none            = No lock strategy. You should handle locking by yourself.
+  # config.lock_strategy = :failed_attempts
+
+  # Defines which key will be used when locking and unlocking an account
+  # config.unlock_keys = [:email]
+
+  # Defines which strategy will be used to unlock an account.
+  # :email = Sends an unlock link to the user email
+  # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
+  # :both  = Enables both strategies
+  # :none  = No unlock strategy. You should handle unlocking by yourself.
+  # config.unlock_strategy = :both
+
+  # Number of authentication tries before locking an account if lock_strategy
+  # is failed attempts.
+  # config.maximum_attempts = 20
+
+  # Time interval to unlock the account if :time is enabled as unlock_strategy.
+  # config.unlock_in = 1.hour
+
+  # Warn on the last attempt before the account is locked.
+  # config.last_attempt_warning = true
+
+  # ==> Configuration for :recoverable
+  #
+  # Defines which key will be used when recovering the password for an account
+  # config.reset_password_keys = [:email]
+
+  # Time interval you can reset your password with a reset password key.
+  # Don't put a too small interval or your users won't have the time to
+  # change their passwords.
+  config.reset_password_within = 6.hours
+
+  # When set to false, does not sign a user in automatically after their password is
+  # reset. Defaults to true, so a user is signed in automatically after a reset.
+  # config.sign_in_after_reset_password = true
+
+  # ==> Configuration for :encryptable
+  # Allow you to use another hashing or encryption algorithm besides bcrypt (default).
+  # You can use :sha1, :sha512 or algorithms from others authentication tools as
+  # :clearance_sha1, :authlogic_sha512 (then you should set stretches above to 20
+  # for default behavior) and :restful_authentication_sha1 (then you should set
+  # stretches to 10, and copy REST_AUTH_SITE_KEY to pepper).
+  #
+  # Require the `devise-encryptable` gem when using anything other than bcrypt
+  # config.encryptor = :sha512
+
+  # ==> Scopes configuration
+  # Turn scoped views on. Before rendering "sessions/new", it will first check for
+  # "users/sessions/new". It's turned off by default because it's slower if you
+  # are using only default views.
+  # config.scoped_views = false
+
+  # Configure the default scope given to Warden. By default it's the first
+  # devise role declared in your routes (usually :user).
+  # config.default_scope = :user
+
+  # Set this configuration to false if you want /users/sign_out to sign out
+  # only the current scope. By default, Devise signs out all scopes.
+  # config.sign_out_all_scopes = true
+
+  # ==> Navigation configuration
+  # Lists the formats that should be treated as navigational. Formats like
+  # :html, should redirect to the sign in page when the user does not have
+  # access, but formats like :xml or :json, should return 401.
+  #
+  # If you have any extra navigational formats, like :iphone or :mobile, you
+  # should add them to the navigational formats lists.
+  #
+  # The "*/*" below is required to match Internet Explorer requests.
+  # config.navigational_formats = ['*/*', :html]
+
+  # The default HTTP method used to sign out a resource. Default is :delete.
+  config.sign_out_via = :delete
+
+  # ==> OmniAuth
+  # Add a new OmniAuth provider. Check the wiki for more information on setting
+  # up on your models and hooks.
+  # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+
+  # ==> Warden configuration
+  # If you want to use other strategies, that are not supported by Devise, or
+  # change the failure app, you can configure them inside the config.warden block.
+  #
+  # config.warden do |manager|
+  #   manager.intercept_401 = false
+  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
+  # end
+
+  # ==> Mountable engine configurations
+  # When using Devise inside an engine, let's call it `MyEngine`, and this engine
+  # is mountable, there are some extra configurations to be taken into account.
+  # The following options are available, assuming the engine is mounted as:
+  #
+  #     mount MyEngine, at: '/my_engine'
+  #
+  # The router that invoked `devise_for`, in the example above, would be:
+  # config.router_name = :my_engine
+  #
+  # When using OmniAuth, Devise cannot automatically set OmniAuth path,
+  # so you need to do it manually. For the users scope, it would be:
+  # config.omniauth_path_prefix = '/my_engine/users/auth'
+end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -1,0 +1,62 @@
+# Additional translations at https://github.com/plataformatec/devise/wiki/I18n
+
+en:
+  devise:
+    confirmations:
+      confirmed: "Your email address has been successfully confirmed."
+      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
+    failure:
+      already_authenticated: "You are already signed in."
+      inactive: "Your account is not activated yet."
+      invalid: "Invalid %{authentication_keys} or password."
+      locked: "Your account is locked."
+      last_attempt: "You have one more attempt before your account is locked."
+      not_found_in_database: "Invalid %{authentication_keys} or password."
+      timeout: "Your session expired. Please sign in again to continue."
+      unauthenticated: "You need to sign in or sign up before continuing."
+      unconfirmed: "You have to confirm your email address before continuing."
+    mailer:
+      confirmation_instructions:
+        subject: "Confirmation instructions"
+      reset_password_instructions:
+        subject: "Reset password instructions"
+      unlock_instructions:
+        subject: "Unlock instructions"
+      password_change:
+        subject: "Password Changed"
+    omniauth_callbacks:
+      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
+      success: "Successfully authenticated from %{kind} account."
+    passwords:
+      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
+      updated: "Your password has been changed successfully. You are now signed in."
+      updated_not_active: "Your password has been changed successfully."
+    registrations:
+      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
+      signed_up: "Welcome! You have signed up successfully."
+      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
+      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
+      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
+      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirm link to confirm your new email address."
+      updated: "Your account has been updated successfully."
+    sessions:
+      signed_in: "Signed in successfully."
+      signed_out: "Signed out successfully."
+      already_signed_out: "Signed out successfully."
+    unlocks:
+      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
+      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
+      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+  errors:
+    messages:
+      already_confirmed: "was already confirmed, please try signing in"
+      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
+      expired: "has expired, please request a new one"
+      not_found: "not found"
+      not_locked: "was not locked"
+      not_saved:
+        one: "1 error prohibited this %{resource} from being saved:"
+        other: "%{count} errors prohibited this %{resource} from being saved:"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  devise_for :users
   root 'comics#index'
 
   resource :comics, only: [:index]

--- a/db/migrate/20160918172040_devise_create_users.rb
+++ b/db/migrate/20160918172040_devise_create_users.rb
@@ -1,0 +1,42 @@
+class DeviseCreateUsers < ActiveRecord::Migration[5.0]
+  def change
+    create_table :users do |t|
+      ## Database authenticatable
+      t.string :email,              null: false, default: ""
+      t.string :encrypted_password, null: false, default: ""
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Trackable
+      t.integer  :sign_in_count, default: 0, null: false
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.string   :current_sign_in_ip
+      t.string   :last_sign_in_ip
+
+      ## Confirmable
+      # t.string   :confirmation_token
+      # t.datetime :confirmed_at
+      # t.datetime :confirmation_sent_at
+      # t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+
+      t.timestamps null: false
+    end
+
+    add_index :users, :email,                unique: true
+    add_index :users, :reset_password_token, unique: true
+    # add_index :users, :confirmation_token,   unique: true
+    # add_index :users, :unlock_token,         unique: true
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,11 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+#########
+# Users #
+#########
+
+puts 'Creating users...'
+
+user = User.where(
+  email: 'email@domain.com',
+).first_or_initialize
+
+user.update(password: 'helloworld')

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
According to http://developer.marvel.com/documentation/attribution we should avoid the API's rate limit by caching requests for 24 hours.

The solution here was to use Redis to save these data and keyed by today's date and the context used to query the API. This way we guarantee that the any data that the API returns, according to a certain context in a certain day, will be cached for 24 hours. 